### PR TITLE
make the swift 5.7 type checker happy

### DIFF
--- a/Source/Charts/Animation/ChartAnimationEasing.swift
+++ b/Source/Charts/Animation/ChartAnimationEasing.swift
@@ -341,7 +341,7 @@ internal struct EasingFunctions
         let s: TimeInterval = 1.70158
         var position: TimeInterval = elapsed / duration
         position -= 1.0
-        return Double( position * position * ((s + 1.0) * position + s) + 1.0 )
+        return Double( position * position * ((s + 1.0) * position + s) + TimeInterval(1.0) )
     }
     
     internal static let EaseInOutBack = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in


### PR DESCRIPTION
fix swift 5.7 compilation by explicitly casting the type of one operand